### PR TITLE
Fix User Notes link in documentation to refer to the proper file

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -66,7 +66,7 @@ Extensions:
                 Installation: getting_started/installation.md
                 FENIX on HPC: getting_started/hpc.md
                 Using FENIX: getting_started/using_fenix.md
-                User Notes: getting_started/user_notes.md
+                User Notes: getting_started/fenix_user_notes.md
                 Contributing to FENIX: getting_started/contributing.md
             Documentation:
                 FENIX-only Syntax: syntax/fenix_only.md


### PR DESCRIPTION
The current link uses TMAP8's version of the file. 

Refs #52