### PR TITLE
Update cardinal submodule

### DIFF
--- a/doc/cardinal_nek_exclude.yml
+++ b/doc/cardinal_nek_exclude.yml
@@ -14,6 +14,7 @@
 - ~source/postprocessors/NekSideExtremeValue.md
 - ~source/postprocessors/NekSideIntegral.md
 - ~source/postprocessors/NekUsrWrkBoundaryIntegral.md
+- ~source/postprocessors/NekViscousSurfaceForce.md
 - ~source/postprocessors/NekVolumeAverage.md
 - ~source/postprocessors/NekVolumeExtremeValue.md
 - ~source/postprocessors/NekVolumeIntegral.md

--- a/doc/content/getting_started/installation.md
+++ b/doc/content/getting_started/installation.md
@@ -78,7 +78,7 @@ Next, some Cardinal dependencies need to be downloaded:
 ```bash
 cd ~/projects/FENIX/cardinal
 git submodule update --init --recursive contrib/openmc
-git submodule update --init --recursive contrib/DAGMC
+git submodule update --init contrib/DAGMC
 git submodule update --init contrib/moab
 ```
 
@@ -180,7 +180,7 @@ git submodule update tmap8
 git submodule update cardinal
 cd cardinal
 git submodule update --recursive contrib/openmc
-git submodule update --recursive contrib/DAGMC
+git submodule update contrib/DAGMC
 git submodule update contrib/moab
 ```
 
@@ -197,7 +197,7 @@ git submodule update tmap8
 git submodule update cardinal
 cd cardinal
 git submodule update --recursive contrib/openmc
-git submodule update --recursive contrib/DAGMC
+git submodule update contrib/DAGMC
 git submodule update contrib/moab
 ```
 

--- a/doc/content/syntax/Problem/Filters/index.md
+++ b/doc/content/syntax/Problem/Filters/index.md
@@ -1,0 +1,1 @@
+!include source/actions/AddFilterAction.md


### PR DESCRIPTION
This PR also removes the recursive updates for DAGMC in the documentation, as pyne is no longer being used (or tested against) by Cardinal. 