### PR TITLE
Enable fully optional docs for Cardinal and TMAP8 and restore Devel-to-Main merges

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -59,8 +59,10 @@ Content:
             - python/TestHarness.md
     tmap8:
         root_dir: ${TMAP8_DIR}/doc/content
+        external: true # optional dependency
     cardinal:
         root_dir: ${CARDINAL_DIR}/doc/content
+        external: true # optional dependency
         content: !include ${ROOT_DIR}/doc/cardinal_nek_exclude.yml
 
 Renderer:

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -107,7 +107,7 @@ Extensions:
     MooseDocs.extensions.acronym:
         acronyms:
             framework: !include ${MOOSE_DIR}/framework/doc/acronyms.yml
-            cardinal: !include ${CARDINAL_DIR}/doc/acronyms.yml
+            cardinal: !include? ${CARDINAL_DIR}/doc/acronyms.yml
             salamander:
                 SALAMANDER: Software for Advanced Large-scale Analysis of MAgnetic confinement for Numerical Design, Engineering & Research
                 PIC: particle-in-cell
@@ -134,8 +134,8 @@ Extensions:
             stochastic_tools: !include ${MOOSE_DIR}/modules/stochastic_tools/doc/sqa_stochastic_tools.yml
             subchannel: !include ${MOOSE_DIR}/modules/subchannel/doc/sqa_subchannel.yml
             thermal_hydraulics: !include ${MOOSE_DIR}/modules/thermal_hydraulics/doc/sqa_thermal_hydraulics.yml
-            tmap8: !include ${TMAP8_DIR}/doc/sqa_tmap8.yml
-            #cardinal: !include ${CARDINAL_DIR}/doc/sqa_cardinal.yml
+            tmap8: !include? ${TMAP8_DIR}/doc/sqa_tmap8.yml
+            #cardinal: !include? ${CARDINAL_DIR}/doc/sqa_cardinal.yml
         reports: !include ${ROOT_DIR}/doc/sqa_reports.yml
         repos:
             default: https://github.com/idaholab/salamander

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -5,36 +5,49 @@ Content:
         root_dir: ${MOOSE_DIR}/framework/doc/content
     chemical_reactions:
         root_dir: ${MOOSE_DIR}/modules/chemical_reactions/doc/content
+        external: true # optional dependency (TMAP8)
     electromagnetics:
         root_dir: ${MOOSE_DIR}/modules/electromagnetics/doc/content
     fluid_properties:
         root_dir: ${MOOSE_DIR}/modules/fluid_properties/doc/content
+        external: true # optional dependency (TMAP8)
     heat_transfer:
         root_dir: ${MOOSE_DIR}/modules/heat_transfer/doc/content
+        external: true # optional dependency (Cardinal and TMAP8)
     misc:
         root_dir: ${MOOSE_DIR}/modules/misc/doc/content
+        external: true # optional dependency (TMAP8)
     navier_stokes:
         root_dir: ${MOOSE_DIR}/modules/navier_stokes/doc/content
+        external: true # optional dependency (Cardinal and TMAP8)
     phase_field:
         root_dir: ${MOOSE_DIR}/modules/phase_field/doc/content
+        external: true # optional dependency (TMAP8)
     reactor:
         root_dir: ${MOOSE_DIR}/modules/reactor/doc/content
+        external: true # optional dependency (Cardinal)
     rdg:
         root_dir: ${MOOSE_DIR}/modules/rdg/doc/content
+        external: true # optional dependency (TMAP8)
     ray_tracing:
         root_dir: ${MOOSE_DIR}/modules/ray_tracing/doc/content
     scalar_transport:
         root_dir: ${MOOSE_DIR}/modules/scalar_transport/doc/content
+        external: true # optional dependency (TMAP8)
     solid_mechanics:
         root_dir: ${MOOSE_DIR}/modules/solid_mechanics/doc/content
+        external: true # optional dependency (Cardinal and TMAP8)
     solid_properties:
         root_dir: ${MOOSE_DIR}/modules/solid_properties/doc/content
+        external: true # optional dependency (Cardinal and TMAP8)
     stochastic_tools:
         root_dir: ${MOOSE_DIR}/modules/stochastic_tools/doc/content
     subchannel:
         root_dir: ${MOOSE_DIR}/modules/subchannel/doc/content
+        external: true # optional dependency (Cardinal)
     thermal_hydraulics:
         root_dir: ${MOOSE_DIR}/modules/thermal_hydraulics/doc/content
+        external: true # optional dependency (Cardinal and TMAP8)
     modules:
         root_dir: ${MOOSE_DIR}/modules/doc/content
         content:

--- a/doc/content/bib/references.bib
+++ b/doc/content/bib/references.bib
@@ -89,3 +89,13 @@ keywords = {Framework, Finite-element, Finite-volume, Parallel, Multiphysics, Mu
   booktitle = {Proceedings of PHYSOR},
   pages = {697-706}
 }
+
+@Article{novak2022_cardinal,
+   author = {A.J. Novak and D. Andrs and P. Shriwise and J. Fang and H. Yuan and D. Shaver and E. Merzari and P.K. Romano and R.C. Martineau},
+    title = {{Coupled {Monte} {Carlo} and Thermal-Fluid Modeling of High Temperature Gas Reactors Using {Cardinal}}},
+  journal = {Annals of Nuclear Energy},
+     year = 2022,
+   volume = 177,
+    pages = {109310},
+      DOI = {10.1016/j.anucene.2022.109310}
+}

--- a/doc/content/citing_salamander.md
+++ b/doc/content/citing_salamander.md
@@ -20,7 +20,7 @@ For all publications that use SALAMANDER, please cite the following.
 
 ## TMAP8
 
-Because SALAMANDER utilizes TMAP8, please refer to [citing_tmap8.md] for all TMAP8-specific citations.
+Because SALAMANDER utilizes TMAP8, please refer to [Citing TMAP8](https://tmap8.inl.gov/citing_tmap8.html) for all TMAP8-specific citations.
 
 ## Cardinal
 

--- a/doc/content/source/userobjects/BorisStepper.md
+++ b/doc/content/source/userobjects/BorisStepper.md
@@ -114,7 +114,7 @@ and the final impulse due to the electric field is then applied to the particle 
   \frac{\Delta t}{2}.
 \end{equation}
 
-The implementation of the Boris algorithm was verified using several single particle motion tests: constant electric field ([boris_stepper/parallel_acceleration.i], [boris_stepper/projectile_motion.i]), cyclotron motion ([/cyclotron_motion.i]), and $\vec{E} \times \vec{B}$ drift motion ([/e_cross_b.i]).
+The implementation of the Boris algorithm was verified using several single particle motion tests: constant electric field ([!file](boris_stepper/parallel_acceleration.i), [!file](boris_stepper/projectile_motion.i)), cyclotron motion ([!file](/cyclotron_motion.i)), and $\vec{E} \times \vec{B}$ drift motion ([!file](/e_cross_b.i)).
 
 # Example Input Syntax
 

--- a/doc/content/source/userobjects/BorisStepper.md
+++ b/doc/content/source/userobjects/BorisStepper.md
@@ -29,7 +29,7 @@ and
 
 where $q$ is the particle's charge, $m$ is the particle's mass, and  $\vec{E}$ and $\vec{B}$ are the electric and magnetic fields that the particle is subject to, respectively.
 
-In the Boris algorithm, \cref{eq:pos,eq:vel} are discretized with a central difference scheme and the acceleration due to the electric field and magnetic field are separated. First, half of the impulse due to the electric field is applied to the particle, as
+In the Boris algorithm, [eq:pos] and [eq:vel] are discretized with a central difference scheme and the acceleration due to the electric field and magnetic field are separated. First, half of the impulse due to the electric field is applied to the particle, as
 
 \begin{equation} \label{eq:e_half1}
   \vec{v}^{\,-}

--- a/doc/content/source/userobjects/ChargeDensityAccumulator.md
+++ b/doc/content/source/userobjects/ChargeDensityAccumulator.md
@@ -68,7 +68,7 @@ The second term of the weak form of Poisson's equation can then be evaluated as
 
 where $M$ is the number of particles which exist on the subdomain where the $j^\text{th}$ test function $\psi_j$ is non-zero. This objects evaluates this source term directly and accumulates the result directly into the residual of the variable representing $\phi$.
 
-This object was verified with the test case found in [/simple_potential_solve.i]. This is the same verification case as presented in [!cite](gall2024verification) only the inner product of the charge density source term and the finite element test function is evaluated directly.
+This object was verified with the test case found in [!file](/simple_potential_solve.i). This is the same verification case as presented in [!cite](gall2024verification) only the inner product of the charge density source term and the finite element test function is evaluated directly.
 
 !alert note
 This representation of the charge density means that direct knowledge of the charge density is lost and only the inner product can be evaluated.

--- a/doc/content/source/userobjects/LeapFrogStepper.md
+++ b/doc/content/source/userobjects/LeapFrogStepper.md
@@ -34,7 +34,7 @@ where $\vec{v}_{n + 1/2}$ is the particles' velocity at a time which is 1/2 of a
 
 where $\vec{r}_{n}$ is the particles position at the time corresponding to the $n^\text{th}$ time step and $\vec{r}_{n-1}$ is the particles position on the previous time step.
 
-The implementation of the leap frog scheme was verified using single particle motion tests: parallel acceleration in an electric field ([leapfrog_stepper/parallel_acceleration.i]), and projectile motion ([leapfrog_stepper/projectile_motion.i]).
+The implementation of the leap frog scheme was verified using single particle motion tests: parallel acceleration in an electric field ([!file](leapfrog_stepper/parallel_acceleration.i)), and projectile motion ([!file](leapfrog_stepper/projectile_motion.i)).
 
 # Example Input Syntax
 

--- a/doc/content/syntax/Cardinal/ICs/BulkEnergyConservation/index.md
+++ b/doc/content/syntax/Cardinal/ICs/BulkEnergyConservation/index.md
@@ -1,1 +1,1 @@
-!include BulkEnergyConservationIC.md
+!include BulkEnergyConservationIC.md optional=True

--- a/doc/content/syntax/Cardinal/ICs/VolumetricHeatSource/index.md
+++ b/doc/content/syntax/Cardinal/ICs/VolumetricHeatSource/index.md
@@ -1,1 +1,1 @@
-!include VolumetricHeatSourceICAction.md
+!include VolumetricHeatSourceICAction.md optional=True

--- a/doc/content/syntax/Cardinal/ICs/index.md
+++ b/doc/content/syntax/Cardinal/ICs/index.md
@@ -1,1 +1,1 @@
-!include syntax/Cardinal/index.md
+!include syntax/Cardinal/index.md optional=True

--- a/doc/content/syntax/Cardinal/index.md
+++ b/doc/content/syntax/Cardinal/index.md
@@ -1,5 +1,5 @@
 # Custom Cardinal Syntax
 
-Custom block syntax is used for both of the [VolumetricHeatSourceICAction.md] and
-[BulkEnergyConservationIC.md] objects. Examples of the usage of this syntax can
+Custom block syntax is used for both of the [VolumetricHeatSourceICAction.md optional=True] and
+[BulkEnergyConservationIC.md optional=True] objects. Examples of the usage of this syntax can
 be found in either of the linked pages.

--- a/doc/content/syntax/Problem/CriticalitySearch/index.md
+++ b/doc/content/syntax/Problem/CriticalitySearch/index.md
@@ -1,1 +1,1 @@
-!include AddCriticalitySearchAction.md
+!include AddCriticalitySearchAction.md optional=True

--- a/doc/content/syntax/Problem/Filters/index.md
+++ b/doc/content/syntax/Problem/Filters/index.md
@@ -1,1 +1,1 @@
-!include source/actions/AddFilterAction.md
+!include source/actions/AddFilterAction.md optional=True

--- a/doc/content/syntax/Problem/MGXS/index.md
+++ b/doc/content/syntax/Problem/MGXS/index.md
@@ -1,1 +1,1 @@
-!include source/actions/SetupMGXSAction.md
+!include source/actions/SetupMGXSAction.md optional=True

--- a/doc/content/syntax/Problem/ModelModifiers/index.md
+++ b/doc/content/syntax/Problem/ModelModifiers/index.md
@@ -1,1 +1,1 @@
-!include source/actions/AddModelModifiersAction.md
+!include source/actions/AddModelModifiersAction.md optional=True

--- a/doc/content/syntax/Problem/Tallies/index.md
+++ b/doc/content/syntax/Problem/Tallies/index.md
@@ -1,1 +1,1 @@
-!include source/actions/AddTallyAction.md
+!include source/actions/AddTallyAction.md optional=True

--- a/doc/content/verification_validation_examples/plasma/particle_stepping.md
+++ b/doc/content/verification_validation_examples/plasma/particle_stepping.md
@@ -170,14 +170,14 @@ Additionally, the Leapfrog stepper produces these expected results as well.
 ## Input Files
 
 There are several input files used for this verification case.
-The two for the Boris stepper can be found at [/boris_stepper/cyclotron_motion.i] and [/boris_stepper/circular_e_field.i].
-The one for the Leapfrog stepper can be found at [/leapfrog_stepper/circular_e_field.i]
+The two for the Boris stepper can be found at [!file](/boris_stepper/cyclotron_motion.i) and [!file](/boris_stepper/circular_e_field.i).
+The one for the Leapfrog stepper can be found at [!file](/leapfrog_stepper/circular_e_field.i).
 Since the majority of the input file contents are the same for all cases, the files are broken up into several common files.
 
-- [/stepper_base.i] disables the field solver, so that particle motion tests are only conducted in fields that are known exactly, and sets up the PICStudy.
-- [/boris_base.i] adds magnetic field components to the list of AuxVariables and selects the [BorisStepper.md] as the particle stepper.
-- [/leapfrog_base.i] selects the [LeapFrogStepper.md] as the particle stepper.
-- [/boris_stepper/cyclotron_motion.i], [/boris_stepper/circular_e_field.i], and [/leapfrog_stepper/circular_e_field.i] set up the initial conditions for the particles and fields for each case.
+- [!file](/stepper_base.i) disables the field solver, so that particle motion tests are only conducted in fields that are known exactly, and sets up the PICStudy.
+- [!file](/boris_base.i) adds magnetic field components to the list of AuxVariables and selects the [BorisStepper.md] as the particle stepper.
+- [!file](/leapfrog_base.i) selects the [LeapFrogStepper.md] as the particle stepper.
+- [!file](/boris_stepper/cyclotron_motion.i), [!file](/boris_stepper/circular_e_field.i), and [!file](/leapfrog_stepper/circular_e_field.i) set up the initial conditions for the particles and fields for each case.
 
 To combine them into one input file when running the simulation, the `!include` feature within MOOSE is utilized.
 

--- a/doc/legacy_unit_tests.yml
+++ b/doc/legacy_unit_tests.yml
@@ -1,0 +1,4 @@
+# Existing GoogleTests awaiting SQA metadata. New entries are prohibited; this list may only shrink.
+unit:
+  - MySampleTests.anotherTest
+  - MySampleTests.descriptiveTestName

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -52,8 +52,8 @@ Requirements:
             - ${MOOSE_DIR}/modules/stochastic_tools/doc/content
             - ${MOOSE_DIR}/modules/subchannel/doc/content
             - ${MOOSE_DIR}/modules/thermal_hydraulics/doc/content
-            - ${TMAP8_DIR}/doc/content
-            - ${CARDINAL_DIR}/doc/content
+            - ${TMAP8_DIR}/doc/content # optional dependency (TMAP8)
+            - ${CARDINAL_DIR}/doc/content # optional dependency (Cardinal)
         directories:
             - ${ROOT_DIR}/test
         show_warning: false


### PR DESCRIPTION
Closes #92 
Closes #158 (expanded scope due to documentation failures)
Closes #159 (expanded scope due to documentation failures)

Requires idaholab/moose#33166, idaholab/moose#33498, and idaholab/moose#33549 to be merged and present in the SALAMANDER repository before this will pass testing. 